### PR TITLE
[merged] commissaire-cli.spec: Remove commissaire-hashpass.

### DIFF
--- a/contrib/package/rpm/commissaire-cli.spec
+++ b/contrib/package/rpm/commissaire-cli.spec
@@ -1,10 +1,10 @@
 Name:           commissaire-cli
 Version:        0.0.1rc2
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        CLI for Commissaire
 License:        LGPLv2+
 URL:            http://github.com/projectatomic/commctl
-Source0:        https://github.com/projectatomic/%{name}/archive/%{version}.tar.gz
+Source0:        https://github.com/projectatomic/commctl/archive/%{version}.tar.gz
 
 BuildArch:      noarch
 
@@ -43,11 +43,13 @@ Command line tools for Commissaire.
 %doc README.md
 %doc CONTRIBUTORS
 %doc MAINTAINERS
-%{_bindir}/commissaire-hashpass
 %{_bindir}/commctl
 %{python2_sitelib}/*
 
 
 %changelog
+* Wed Apr 20 2016 Matthew Barnes <mbarnes@redhat.com> - 0.0.1rc2-6
+* commissaire-hashpass is now 'commctl create passhash'.
+
 * Mon Apr  4 2016 Steve Milner <smilner@redhat.com> - 0.0.1rc2-5
 * commctl and commissaire-hash-pass are now their own package.

--- a/contrib/package/rpm/commissaire-client.spec
+++ b/contrib/package/rpm/commissaire-client.spec
@@ -1,4 +1,4 @@
-Name:           commissaire-cli
+Name:           commissaire-client
 Version:        0.0.1rc2
 Release:        6%{?dist}
 Summary:        CLI for Commissaire

--- a/contrib/package/rpm/commissaire-client.spec
+++ b/contrib/package/rpm/commissaire-client.spec
@@ -1,6 +1,6 @@
 Name:           commissaire-client
-Version:        0.0.1rc2
-Release:        6%{?dist}
+Version:        0.0.1rc3
+Release:        1%{?dist}
 Summary:        CLI for Commissaire
 License:        LGPLv2+
 URL:            http://github.com/projectatomic/commctl
@@ -48,8 +48,11 @@ Command line tools for Commissaire.
 
 
 %changelog
+* Wed Apr 20 2016 Matthew Barnes <mbarnes@redhat.com> - 0.0.1rc3-1
+- Update for RC3.
+
 * Wed Apr 20 2016 Matthew Barnes <mbarnes@redhat.com> - 0.0.1rc2-6
-* commissaire-hashpass is now 'commctl create passhash'.
+- commissaire-hashpass is now 'commctl create passhash'.
 
 * Mon Apr  4 2016 Steve Milner <smilner@redhat.com> - 0.0.1rc2-5
-* commctl and commissaire-hash-pass are now their own package.
+- commctl and commissaire-hash-pass are now their own package.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ test_require = extract_requirements('test-requirements.txt')
 
 setup(
     name='commctl',
-    version='0.0.1rc2',
+    version='0.0.1rc3',
     description='CLI for Commissaire',
     author=extract_names('CONTRIBUTORS'),
     maintainer=extract_names('MAINTAINERS'),


### PR DESCRIPTION
Couple other things:
- Do you still want the package named `commissaire-cli` instead of `commctl`?  No preference, just checking.
-  Can we cut a release after this so I can start a Fedora review?
