### PR TITLE
[merged] Make upgrade version a positional argument.

### DIFF
--- a/src/commctl/cli.py
+++ b/src/commctl/cli.py
@@ -289,9 +289,9 @@ class Client(object):
         path = '/api/v0/cluster/{0}/restart'.format(name)
         return self._get(path)
 
-    def create_restart(self, name, **kwargs):
+    def start_restart(self, name, **kwargs):
         """
-        Attempts to create a cluster restart.
+        Attempts to initiate a cluster restart.
 
         :param name: The name of the cluster
         :type name: str
@@ -313,9 +313,9 @@ class Client(object):
         path = '/api/v0/cluster/{0}/upgrade'.format(name)
         return self._get(path)
 
-    def create_upgrade(self, name, version, **kwargs):
+    def start_upgrade(self, name, version, **kwargs):
         """
-        Attempts to create a cluster upgrade.
+        Attempts to initiate a cluster upgrade.
 
         :param name: The name of the cluster
         :type name: str
@@ -554,15 +554,6 @@ def add_subparsers(argument_parser):
     host_parser.add_argument(
         '-c', '--cluster', help='Add host to the cluster named CLUSTER')
 
-    restart_parser = create_sp.add_parser('restart')
-    restart_parser.required = True
-    restart_parser.add_argument('name', help='Name of the cluster')
-
-    upgrade_parser = create_sp.add_parser('upgrade')
-    upgrade_parser.required = True
-    upgrade_parser.add_argument('name', help='Name of the cluster')
-    upgrade_parser.add_argument('version', help='Version to upgrade to')
-
     passhash_parser = create_sp.add_parser('passhash')
     passhash_parser.required = True
     passhash_parser.add_argument(
@@ -601,3 +592,18 @@ def add_subparsers(argument_parser):
     hosts_parser.add_argument(
         'name', nargs='?', default=None,
         help='Name of the cluster (omit to list all hosts)')
+
+    # Command: start ...
+
+    start_parser = sp.add_parser('start')
+    start_sp = start_parser.add_subparsers(dest='sub_command')
+    start_sp.required = True
+
+    restart_parser = start_sp.add_parser('restart')
+    restart_parser.required = True
+    restart_parser.add_argument('name', help='Name of the cluster')
+
+    upgrade_parser = start_sp.add_parser('upgrade')
+    upgrade_parser.required = True
+    upgrade_parser.add_argument('name', help='Name of the cluster')
+    upgrade_parser.add_argument('version', help='Version to upgrade to')

--- a/src/commctl/cli.py
+++ b/src/commctl/cli.py
@@ -313,7 +313,7 @@ class Client(object):
         path = '/api/v0/cluster/{0}/upgrade'.format(name)
         return self._get(path)
 
-    def create_upgrade(self, name, **kwargs):
+    def create_upgrade(self, name, version, **kwargs):
         """
         Attempts to create a cluster upgrade.
 
@@ -323,7 +323,7 @@ class Client(object):
         :type kwargs: dict
         """
         path = '/api/v0/cluster/{0}/upgrade'.format(name)
-        return self._put(path, {'upgrade_to': kwargs['upgrade_to']})
+        return self._put(path, {'upgrade_to': version})
 
     def create_passhash(self, **kwargs):
         """
@@ -561,10 +561,7 @@ def add_subparsers(argument_parser):
     upgrade_parser = create_sp.add_parser('upgrade')
     upgrade_parser.required = True
     upgrade_parser.add_argument('name', help='Name of the cluster')
-    # XXX Should this be positional too since it's required?
-    upgrade_parser.add_argument(
-        '-u', '--upgrade-to', required=True,
-        help='Version to upgrade to')
+    upgrade_parser.add_argument('version', help='Version to upgrade to')
 
     passhash_parser = create_sp.add_parser('passhash')
     passhash_parser.required = True

--- a/test/test_client_script.py
+++ b/test/test_client_script.py
@@ -88,13 +88,15 @@ class TestClientScript(TestCase):
                     ['cluster'],
                     ['host', '-c', 'honeynut', '1.2.3.4'],
                     ['restart'],
-                    ['upgrade', '-u', '1']):
+                    ['upgrade']):
                 mock_return = requests.Response()
                 mock_return._content = '{}'
                 mock_return.status_code = 201
                 _put.return_value = mock_return
 
                 sys.argv[2:] = subcmd + ['test']
+                if subcmd[0] == 'upgrade':
+                    sys.argv.append('1')  # arbitrary version
                 print sys.argv
                 client_script.main()
                 self.assertEquals(1, _put.call_count)

--- a/test/test_client_script.py
+++ b/test/test_client_script.py
@@ -86,17 +86,13 @@ class TestClientScript(TestCase):
             _realpath.return_value = self.conf
             for subcmd in (
                     ['cluster'],
-                    ['host', '-c', 'honeynut', '1.2.3.4'],
-                    ['restart'],
-                    ['upgrade']):
+                    ['host', '-c', 'honeynut', '1.2.3.4']):
                 mock_return = requests.Response()
                 mock_return._content = '{}'
                 mock_return.status_code = 201
                 _put.return_value = mock_return
 
                 sys.argv[2:] = subcmd + ['test']
-                if subcmd[0] == 'upgrade':
-                    sys.argv.append('1')  # arbitrary version
                 print sys.argv
                 client_script.main()
                 self.assertEquals(1, _put.call_count)
@@ -144,6 +140,30 @@ class TestClientScript(TestCase):
                 client_script.main()
                 self.assertEquals(1, _get.call_count)
                 _get.reset_mock()
+
+    def test_client_script_start(self):
+        """
+        Verify use cases for the client_script start command.
+        """
+        sys.argv = ['', 'start']
+        with contextlib.nested(
+                mock.patch('requests.Session.put'),
+                mock.patch('os.path.realpath')
+                ) as (_put, _realpath):
+            _realpath.return_value = self.conf
+            for subcmd in (['restart'], ['upgrade']):
+                mock_return = requests.Response()
+                mock_return._content = '{}'
+                mock_return.status_code = 201
+                _put.return_value = mock_return
+
+                sys.argv[2:] = subcmd + ['test']
+                if subcmd[0] == 'upgrade':
+                    sys.argv.append('1')  # arbitrary version
+                print sys.argv
+                client_script.main()
+                self.assertEquals(1, _put.call_count)
+                _put.reset_mock()
 
     def test_client_script_passhash_with_password(self):
         """


### PR DESCRIPTION
I should have just done this with the module work, but the `--upgrade_to` option which is not optional is proving to be an awkward wart in the manpage I'm writing for `atomic`.  I'd prefer it be positional: `commctl create upgrade my_cluster 1.2.3`

Also, somewhat related, but are you still okay with `create` as a verb for `upgrade` and `restart`?  I think we once talked about it sounding a little awkward, as opposed to something like `start`.  Once I add this stuff to `atomic`, I feel like we're kinda stuck with it.  So last call for changes.
