### PR TITLE
[merged] cli: Add a breadcrumb for atomic

### DIFF
--- a/src/commctl/cli.py
+++ b/src/commctl/cli.py
@@ -380,6 +380,9 @@ class Dispatcher(object):
     # This is overridden by subclasses.
     argument_parser = None
 
+    # For atomic: allow non-root users to run these commands.
+    requires_root = False
+
     def __init__(self):
         self._args = None
 


### PR DESCRIPTION
Signals `atomic` to let non-root users run these commands (assuming Dan accepts my changes).

Thought I pushed this already but I'm juggling too many branches here...
