### PR TITLE
[merged] Make command syntax more palatable to atomic

### DIFF
--- a/src/commctl/client_script.py
+++ b/src/commctl/client_script.py
@@ -18,9 +18,27 @@
 Client CLI for commissaire.
 """
 
+from __future__ import print_function
+
 import argparse
 
 import commctl.cli
+
+
+def do_passhash(args):
+    """
+    Uses bcrypt to hash a password.
+    """
+    import bcrypt
+    if args.password is not None:
+        pw = args.password
+    elif args.file is not None:
+        pw = args.file.read()
+    else:
+        import getpass
+        pw = getpass.getpass()
+    salt = bcrypt.gensalt(log_rounds=args.rounds)
+    return bcrypt.hashpw(pw, salt)
 
 
 def main():
@@ -30,7 +48,7 @@ def main():
     epilog = 'Example: commctl create upgrade datacenter1 -u 7.2.2'
 
     parser = argparse.ArgumentParser(epilog=epilog)
-    subparser = parser.add_subparsers()
+    subparser = parser.add_subparsers(dest='command')
 
     cluster_parser = subparser.add_parser('cluster')
     commctl.cli.add_cluster_commands(cluster_parser)
@@ -38,11 +56,28 @@ def main():
     host_parser = subparser.add_parser('host')
     commctl.cli.add_host_commands(host_parser)
 
+    # XXX passhash is more like a helper script.  Keep it out
+    #     of the shared API for now, and exclusive to commctl.
+    subcmd_parser = subparser.add_parser('passhash')
+    subcmd_parser.add_argument(
+        '-p', '--password', help='Password to hash')
+    subcmd_parser.add_argument(
+        '-f', '--file', type=argparse.FileType('rb'),
+        help='Password file to hash (or "-" for stdin)')
+    subcmd_parser.add_argument(
+        '-r', '--rounds', type=int, default=12, help='Number of rounds')
+
     args = parser.parse_args()
 
-    dispatcher = args._class()
-    dispatcher.set_args(args)
-    getattr(dispatcher, args.func)()
+    if args.command == 'passhash':
+        try:
+            print(do_passhash(args))
+        except Exception as ex:
+            parser.error(ex)
+    else:
+        dispatcher = args._class()
+        dispatcher.set_args(args)
+        getattr(dispatcher, args.func)()
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/src/commctl/client_script.py
+++ b/src/commctl/client_script.py
@@ -30,12 +30,19 @@ def main():
     epilog = 'Example: commctl create upgrade datacenter1 -u 7.2.2'
 
     parser = argparse.ArgumentParser(epilog=epilog)
-    commctl.cli.add_subparsers(parser)
+    subparser = parser.add_subparsers()
+
+    cluster_parser = subparser.add_parser('cluster')
+    commctl.cli.add_cluster_commands(cluster_parser)
+
+    host_parser = subparser.add_parser('host')
+    commctl.cli.add_host_commands(host_parser)
 
     args = parser.parse_args()
+
     dispatcher = args._class()
     dispatcher.set_args(args)
-    dispatcher.dispatch()
+    getattr(dispatcher, args.func)()
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
Second pass at this.

`add_subparsers()` now takes keyword arguments to override base command names, the driving use case being `host='rhost'` for atomic.  I didn't want `commctl rhost`.

Additionally, this inverts the command syntax.  The commands are now:

```
    commctl cluster create
    commctl cluster delete
    commctl cluster get
    commctl cluster list
    commctl cluster restart start
    commctl cluster restart status
    commctl cluster upgrade start
    commctl cluster upgrade status
    commctl host create
    commctl host delete
    commctl host get
    commctl host list
    commctl passhash
```

Note what I did for `restart` and `upgrade`.  My reasoning there is by principle of least surprise I don't want `atomic upgrade` to be a thing.  I've mistyped that too many times when I meant `atomic host upgrade` and I think it would be misleading.

Also, `passhash` is an oddball case.  I debated whether to even add that to atomic.
