### PR TITLE
[merged] Add host name lookup to address arguments.

### DIFF
--- a/src/commctl/cli.py
+++ b/src/commctl/cli.py
@@ -27,6 +27,7 @@ import json
 import os
 import os.path
 import platform
+import socket
 import yaml
 
 import requests
@@ -38,6 +39,23 @@ if platform.python_version_tuple()[0] == '2':
 
 def default_config_file():
     return os.path.realpath(os.path.expanduser('~/.commissaire.json'))
+
+
+def host_address(arg):
+    """
+    Conversion function for host address arguments.  Attempts to resolve
+    a host name to an IP address.
+
+    :param arg: Input string from command-line
+    :type arg: string
+    :returns: IP address
+    :rtype: string
+    """
+    try:
+        return socket.gethostbyname(arg)
+    except socket.gaierror as ex:
+        message = '{0}: {1}'.format(arg, ex.strerror)
+        raise argparse.ArgumentTypeError(message)
 
 
 class ClientError(Exception):
@@ -643,7 +661,9 @@ def add_host_commands(argument_parser):
     # Sub-command: host create
     verb_parser = subject_subparser.add_parser('create')
     verb_parser.required = True
-    verb_parser.add_argument('address', help='IP address of the host')
+    verb_parser.add_argument(
+        'address', type=host_address,
+        help='Host name or IP address')
     verb_parser.add_argument(
         'ssh-priv-key', type=argparse.FileType('rb'),
         help='SSH private key file (or "-" for stdin)')
@@ -653,12 +673,16 @@ def add_host_commands(argument_parser):
     # Sub-command: host delete
     verb_parser = subject_subparser.add_parser('delete')
     verb_parser.required = True
-    verb_parser.add_argument('address', help='IP address of the host')
+    verb_parser.add_argument(
+        'address', type=host_address,
+        help='Host name or IP address')
 
     # Sub-command: host get
     verb_parser = subject_subparser.add_parser('get')
     verb_parser.required = True
-    verb_parser.add_argument('address', help='IP address of the host')
+    verb_parser.add_argument(
+        'address', type=host_address,
+        help='Host name or IP address')
 
     # Sub-command: host list
     verb_parser = subject_subparser.add_parser('list')

--- a/test/test_client_script.py
+++ b/test/test_client_script.py
@@ -65,7 +65,7 @@ class TestClientScript(TestCase):
                     (['cluster', 'list'], '[]'),
                     (['cluster', 'restart', 'status', 'test'], '{}'),
                     (['cluster', 'upgrade', 'status', 'test'], '{}'),
-                    (['host', 'get', 'test'], '{}'),
+                    (['host', 'get', 'localhost'], '{}'),
                     (['host', 'list'], '[]'),
                     (['host', 'list', 'test'], '[]')):
                 mock_return = requests.Response()
@@ -121,14 +121,14 @@ class TestClientScript(TestCase):
                 mock.patch('os.path.realpath')) as (_delete, _realpath):
             _realpath.return_value = self.conf
             for cmd in (
-                    ['cluster', 'delete'],
-                    ['host', 'delete']):
+                    ['cluster', 'delete', 'test'],
+                    ['host', 'delete', 'localhost']):
                 mock_return = requests.Response()
                 mock_return._content = '{}'
                 mock_return.status_code = 200
                 _delete.return_value = mock_return
 
-                sys.argv[1:] = cmd + ['test']
+                sys.argv[1:] = cmd
                 print sys.argv
                 client_script.main()
                 self.assertEquals(1, _delete.call_count)


### PR DESCRIPTION
Got tired of having to manually refer back to `/etc/hosts` in my test environment.
