### PR TITLE
[merged] Allow ssh to host node via commctl.

### DIFF
--- a/src/commctl/cli.py
+++ b/src/commctl/cli.py
@@ -431,7 +431,7 @@ class Client(object):
                         base64.decodestring(result['ssh_priv_key']))
                 os.close(fd)
                 print('Calling ssh...')
-                subprocess.call('ssh -i {} -l {} {} {}'.format(
+                subprocess.call('ssh -i {0} -l {1} {2} {3}'.format(
                     ssh_priv_key_path,
                     result['remote_user'],
                     ' '.join(extra_args),

--- a/src/commctl/cli.py
+++ b/src/commctl/cli.py
@@ -430,12 +430,11 @@ class Client(object):
                     ssh_priv_key_fobj.write(
                         base64.decodestring(result['ssh_priv_key']))
                 os.close(fd)
-                print('Calling ssh...')
-                subprocess.call('ssh -i {0} -l {1} {2} {3}'.format(
-                    ssh_priv_key_path,
-                    result['remote_user'],
-                    ' '.join(extra_args),
-                    hostname), shell=True)
+                ssh_cmd = ('ssh -i {0} -l {1} {2} {3}'.format(
+                    ssh_priv_key_path, result['remote_user'],
+                    ' '.join(extra_args), hostname))
+                print('Calling ssh command via shell: "{0}"'.format(ssh_cmd))
+                subprocess.call(ssh_cmd, shell=True)
             finally:
                 # Remove the keyfile
                 if ssh_priv_key_path:
@@ -744,7 +743,6 @@ def add_host_commands(argument_parser):
         'name', nargs='?', default=None,
         help='Name of the cluster (omit to list all hosts)')
 
-    # XXX: Reviewer, does it make sense for this to live here?
     # Sub-command: host ssh
     verb_parser = subject_subparser.add_parser('ssh')
 

--- a/test/test_client_script.py
+++ b/test/test_client_script.py
@@ -140,13 +140,11 @@ class TestClientScript(TestCase):
         Verify use cases for the client_script ssh requests.
         """
         sys.argv = ['', 'host', 'ssh']
-        with contextlib.nested(
-                mock.patch('requests.Session.get'),
-                mock.patch('os.path.realpath'),
-                mock.patch('subprocess.call'),
-                mock.patch('tempfile.mkstemp'),
-                mock.patch('os.close')) as (
-                    _get, _realpath, _call, _mkstemp, _close):
+        with mock.patch('requests.Session.get') as _get, \
+                mock.patch('os.path.realpath') as _realpath, \
+                mock.patch('subprocess.call') as _call, \
+                mock.patch('tempfile.mkstemp') as _mkstemp, \
+                mock.patch('os.close') as _close:
             _realpath.return_value = self.conf
             _mkstemp.return_value = (1, '/tmp/test_key_file')
             for cmd in (

--- a/test/test_client_script.py
+++ b/test/test_client_script.py
@@ -160,7 +160,7 @@ class TestClientScript(TestCase):
                 _get.return_value = mock_return
 
                 sys.argv[3:] = cmd
-                expected = 'ssh -i /tmp/test_key_file -l root {} {}'.format(
+                expected = 'ssh -i /tmp/test_key_file -l root {0} {1}'.format(
                     ' '.join(cmd[1:]), cmd[0])
                 print sys.argv
                 client_script.main()

--- a/test/test_client_script.py
+++ b/test/test_client_script.py
@@ -135,6 +135,40 @@ class TestClientScript(TestCase):
                 self.assertEquals(num_things, _delete.call_count)
                 _delete.reset_mock()
 
+    def test_client_script_host_ssh(self):
+        """
+        Verify use cases for the client_script ssh requests.
+        """
+        sys.argv = ['', 'host', 'ssh']
+        with contextlib.nested(
+                mock.patch('requests.Session.get'),
+                mock.patch('os.path.realpath'),
+                mock.patch('subprocess.call'),
+                mock.patch('tempfile.mkstemp'),
+                mock.patch('os.close')) as (
+                    _get, _realpath, _call, _mkstemp, _close):
+            _realpath.return_value = self.conf
+            _mkstemp.return_value = (1, '/tmp/test_key_file')
+            for cmd in (
+                    ['127.0.0.1'],
+                    ['127.0.0.1', '-p 22'],
+                    ['127.0.0.1', '-p 22 -v']):
+                mock_return = requests.Response()
+                mock_return._content = (
+                    '{"ssh_priv_key": "dGVzdAo=", "remote_user": "root"}')
+                mock_return.status_code = 200
+                _get.return_value = mock_return
+
+                sys.argv[3:] = cmd
+                expected = 'ssh -i /tmp/test_key_file -l root {} {}'.format(
+                    ' '.join(cmd[1:]), cmd[0])
+                print sys.argv
+                client_script.main()
+                _get.assert_called_once()
+                _call.assert_called_once_with(expected, shell=True)
+                _call.reset_mock()
+                _get.reset_mock()
+
     def test_client_script_passhash_with_password(self):
         """
         Verify passhash works via --password


### PR DESCRIPTION
With the addition of the HostCreds resource it's now possible explicitly
gain access to the remote_user and ssh_priv_key for a host. This patch
requests the ssh private key and user, creates a temporary file to house
the key, and then uses that key and remote user with ssh to create a
connection. After the connection is finished (or if the connection fails
to be made) the local copy of the ssh key is deleted.

Will require https://github.com/projectatomic/commissaire/pull/151.
