### PR TITLE
Updated cluster create command to take in network.

### DIFF
--- a/src/commctl/cli.py
+++ b/src/commctl/cli.py
@@ -268,6 +268,7 @@ class Client(object):
         path = '/api/v0/cluster/{0}'.format(name)
         data = {
             'type': kwargs['type'],
+            'network': kwargs['network'],
         }
         return self._put(path, data)
 
@@ -676,6 +677,9 @@ def add_cluster_commands(argument_parser):
     verb_parser.add_argument(
         '-t', '--type', help='Type of the cluster',
         choices=('kubernetes', 'host_only'), default='kubernetes')
+    verb_parser.add_argument(
+        '-n', '--network', help='Type of network',
+        choices=('flannel_etcd', 'flannel_server'), default='flannel_etcd')
     verb_parser.add_argument('name', help='Name of the cluster')
 
     # Sub-command: cluster delete

--- a/src/commctl/client_script.py
+++ b/src/commctl/client_script.py
@@ -56,6 +56,9 @@ def main():
     host_parser = subparser.add_parser('host')
     commctl.cli.add_host_commands(host_parser)
 
+    networks_parser = subparser.add_parser('network')
+    commctl.cli.add_network_commands(networks_parser)
+
     # XXX passhash is more like a helper script.  Keep it out
     #     of the shared API for now, and exclusive to commctl.
     subcmd_parser = subparser.add_parser('passhash')

--- a/test/test_client_script.py
+++ b/test/test_client_script.py
@@ -67,10 +67,14 @@ class TestClientScript(TestCase):
                     (['cluster', 'list'], '[]'),
                     (['cluster', 'restart', 'status', 'test'], '{}'),
                     (['cluster', 'upgrade', 'status', 'test'], '{}'),
+                    (['cluster', 'restart', 'status', 'test'], '{}'),
                     (['host', 'get', 'localhost'], '{}'),
                     (['host', 'list'], '[]'),
                     (['host', 'list', 'test'], '[]'),
-                    (['host', 'status', 'localhost'], '{}')):
+                    (['host', 'status', 'localhost'], '{}'),
+                    (['network', 'get', 'test'], '{}'),
+                    (['network', 'list'], '[]'),
+                    ):
                 mock_return = requests.Response()
                 mock_return._content = content
                 mock_return.status_code = 200
@@ -127,7 +131,9 @@ class TestClientScript(TestCase):
                     ['cluster', 'delete', 'test'],
                     ['cluster', 'delete', 'test1', 'test2'],
                     ['host', 'delete', 'localhost'],
-                    ['host', 'delete', '10.0.0.1', '10.0.0.2', '10.0.0.3']):
+                    ['host', 'delete', '10.0.0.1', '10.0.0.2', '10.0.0.3'],
+                    ['network', 'delete', 'test'],
+                    ['network', 'delete', 'test', 'test2', 'test3']):
                 mock_return = requests.Response()
                 mock_return._content = '{}'
                 mock_return.status_code = 200

--- a/test/test_client_script.py
+++ b/test/test_client_script.py
@@ -94,7 +94,9 @@ class TestClientScript(TestCase):
             _realpath.return_value = self.conf
             for cmd in (
                     ['cluster', 'create'],
+                    ['cluster', 'create', '-n', 'flannel_etcd'],
                     ['cluster', 'create', '-t', 'kubernetes'],
+                    ['cluster', 'create', '-t', 'kubernetes', '-n', 'flannel_etcd'],
                     ['cluster', 'deploy', 'start'],
                     ['cluster', 'restart', 'start'],
                     ['cluster', 'upgrade', 'start'],


### PR DESCRIPTION
This will be used as part of the flanneld/etcd decoupling.

The update includes a new flag: `-n/--network`. It takes either
`flannel_etcd` or `flannel_service`. If not specified `flannel_etcd`
is used.

Example:

```
    $ commctl cluster create -n flannel_service
    Success
```
