### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-#  - "3.3"
+  - "3.3"
 install:
   - "pip install -r requirements.txt"
   - "pip install -r test-requirements.txt"

--- a/src/commctl/cli.py
+++ b/src/commctl/cli.py
@@ -35,7 +35,7 @@ import requests
 
 # If we are on Python 2.x use raw_input as input
 if platform.python_version_tuple()[0] == '2':
-    input = raw_input
+    input = raw_input  # noqa
 
 
 def default_config_file():
@@ -571,6 +571,7 @@ class Client(object):
         :param kwargs: Any other keyword arguments
         :type kwargs: dict
         """
+        import platform
         import subprocess
         # XXX: Normally we should use subprocess.call without the shell. Since
         #      this command is really a wrapper around a shell command we allow
@@ -581,9 +582,14 @@ class Client(object):
         if result.get('ssh_priv_key') and result.get('remote_user'):
             try:
                 fd, ssh_priv_key_path = tempfile.mkstemp()
-                with open(ssh_priv_key_path, 'w') as ssh_priv_key_fobj:
-                    ssh_priv_key_fobj.write(
-                        base64.decodestring(result['ssh_priv_key']))
+                with open(ssh_priv_key_path, 'wb') as ssh_priv_key_fobj:
+                    if platform.python_version_tuple()[0] == '2':
+                        decoded_key = base64.decodestring(
+                            result['ssh_priv_key'])
+                    else:
+                        decoded_key = base64.decodebytes(
+                            bytes(result['ssh_priv_key'], 'utf8'))
+                    ssh_priv_key_fobj.write(decoded_key)
                 os.close(fd)
                 ssh_cmd = ('ssh -i {0} -l {1} {2} {3}'.format(
                     ssh_priv_key_path, result['remote_user'],

--- a/src/commctl/kubeconfig.py
+++ b/src/commctl/kubeconfig.py
@@ -82,11 +82,16 @@ class KubeUser:
             self.type = 'token'
         elif spec['user'].get('username') and spec['user'].get('password'):
             import base64
+            import platform
             self.username = spec['user']['username']
             self.password = spec['user']['password']
+            user_pass = '{}:{}'.format(self.username, self.password)
+            if platform.python_version_tuple()[0] == '2':
+                basic_auth = base64.encodestring(user_pass)
+            else:
+                basic_auth = base64.encodebytes(bytes(user_pass, 'utf8'))
             self.auth_headers = [(
-                'Authorization', 'Basic ' + base64.encodestring(
-                    '{}:{}'.format(self.username, self.password)))]
+                'Authorization', 'Basic ' + str(basic_auth))]
             self.type = 'password'
         elif (spec['user'].get('client-certificate') and
                 spec['user'].get('client-key')):  # pragma: no cover


### PR DESCRIPTION
The `atomic` command uses `commctl` as a module, and supports both Python 2 and 3, which means *we* have to support both Python 2 and 3.