### PR TITLE
cli: User data command

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 ignore = E402
-exclude = test/*
+exclude = test/*,src/commctl/data/*
 #max-complexity = 20
 
 [nosetests]

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     package_dir={'': 'src'},
     packages=find_packages('src'),
     package_data={
-        '': ['data/ansible/playbooks/*', 'data/templates/*'],
+        '': ['data/*'],
     },
     entry_points={
         'console_scripts': [

--- a/src/commctl/client_script.py
+++ b/src/commctl/client_script.py
@@ -62,9 +62,6 @@ def main():
         help='Generates a user-data file for use with cloud-init',
         epilog='Example: commctl user-data -p -c my_cluster cluster.userdata')
     user_data_parser.add_argument(
-        'outfile',
-        help='Path and file name to output the user-data contents')
-    user_data_parser.add_argument(
         '-e', '--endpoint', required=True,
         help='Commissaire endpoint to use during bootstrapping')
     user_data_parser.add_argument(
@@ -88,6 +85,8 @@ def main():
         default='/root/.ssh/authorized_keys')
     user_data_parser.add_argument(
         '-C', '--cloud-init', help='cloud-init.txt file to use')
+    user_data_parser.add_argument(
+        '-o', '--outfile', help='Output file. If empty STDOUT is used')
 
     args = parser.parse_args()
 

--- a/src/commctl/client_script.py
+++ b/src/commctl/client_script.py
@@ -25,22 +25,6 @@ import argparse
 import commctl.cli
 
 
-def do_passhash(args):
-    """
-    Uses bcrypt to hash a password.
-    """
-    import bcrypt
-    if args.password is not None:
-        pw = args.password
-    elif args.file is not None:
-        pw = args.file.read()
-    else:
-        import getpass
-        pw = getpass.getpass()
-    salt = bcrypt.gensalt(log_rounds=args.rounds)
-    return bcrypt.hashpw(pw, salt)
-
-
 def main():
     """
     Main script entry point.
@@ -77,6 +61,7 @@ def main():
 
     try:
         if args.command == 'passhash':
+            from commctl.helpers import do_passhash
             print(do_passhash(args))
         else:
             dispatcher = args._class()

--- a/src/commctl/client_script.py
+++ b/src/commctl/client_script.py
@@ -60,7 +60,8 @@ def main():
     user_data_parser = subparser.add_parser(
         'user-data',
         help='Generates a user-data file for use with cloud-init',
-        epilog='Example: commctl user-data -p -c my_cluster cluster.userdata')
+        epilog=(
+            'Example: commctl user-data -p -c my_cluster -o cluster.userdata'))
     user_data_parser.add_argument(
         '-e', '--endpoint', required=True,
         help='Commissaire endpoint to use during bootstrapping')

--- a/src/commctl/client_script.py
+++ b/src/commctl/client_script.py
@@ -45,7 +45,7 @@ def main():
     """
     Main script entry point.
     """
-    epilog = 'Example: commctl create upgrade datacenter1 -u 7.2.2'
+    epilog = 'Example: commctl create deploy datacenter1 -u 7.2.2'
 
     parser = argparse.ArgumentParser(epilog=epilog)
     subparser = parser.add_subparsers(dest='command')

--- a/src/commctl/client_script.py
+++ b/src/commctl/client_script.py
@@ -87,7 +87,7 @@ def main():
     user_data_parser.add_argument(
         '-C', '--cloud-init', help='cloud-init.txt file to use')
     user_data_parser.add_argument(
-        '-o', '--outfile', help='Output file. If empty STDOUT is used')
+        '-o', '--outfile', help='Output file. If omitted STDOUT is used')
 
     args = parser.parse_args()
 

--- a/src/commctl/data/cloud-init.txt
+++ b/src/commctl/data/cloud-init.txt
@@ -1,0 +1,3 @@
+#cloud-config
+
+final_message: "Finished booting"

--- a/src/commctl/data/part-handler.py
+++ b/src/commctl/data/part-handler.py
@@ -1,0 +1,202 @@
+#part-handler
+# vi: syntax=python ts=4
+#
+#  Handles a 'text/x-commissaire-host' part of a cloud-init user data file.
+#  Registers the host with a Commissaire server using the given parameters.
+#
+#  Data format is a JSON object with the following members:
+#
+#  "endpoint"
+#    Base URI of the Commissaire service.
+#
+#  "username"  (optional)
+#    The user name to use for Commissaire service authentication.
+#
+#  "password"  (optional)
+#    The password to use for Commissaire service authentication.
+#
+#  "cluster"  (optional)
+#    The name of the cluster to join.
+#
+#  "remote_user"  (optional)
+#    The user used to ssh into the remote system. By default this is "root"
+#
+#  "ssh_key_path"  (optional)
+#    The private SSH key file for the root account of this host.
+#    Defaults to '/root/.ssh/id_rsa' and, if necessary, generates
+#    a public/private key pair with no passphrase.
+#
+#  "authorized_keys_path"  (optional)
+#    The path to the authorized_keys file. By default this is
+#    /root/.ssh/authorized_keys
+#
+#
+# TO CREATE A USER-DATA FILE
+# ::::::::::::::::::::::::::
+#
+# The user-data file must use MIME multipart/mixed format.  You can generate
+# such a file with the "make-mime.py" script in cloud-init's tools directory:
+#
+# http://bazaar.launchpad.net/~cloud-init-dev/cloud-init/trunk/view/head:/tools/make-mime.py
+#
+# Suppose the text/cloud-config data are in the file 'config.txt' and the
+# text/x-commissaire-host parameters are in the file 'commissaire.txt',
+# then to generate a user-data file that embeds this script:
+#
+#    $ python make-mime.py \
+#             --attach config.txt:cloud-config \
+#             --attach part-handler.py:part-handler \
+#             --attach commissaire.txt:x-commissaire-host \
+#             > user-data
+#
+# Alternatively, you can instruct cloud-init to download this part handler
+# script from a URL at boot time by attaching a text/x-include-url file:
+#
+#    $ python make-mime.py \
+#             --attach config.txt:cloud-config \
+#             --attach include.txt:x-include-url \
+#             --attach commissaire.txt:x-commissaire-host \
+#             > user-data
+#
+# Whether the part handler is included by way of direct embedding or a URL,
+# it must appear in the multipart file BEFORE the text/x-commissaire-host
+# part so cloud-init knows how to handle the text/x-commissaire-host part.
+#
+
+from __future__ import print_function
+
+import stat
+import os
+import os.path
+import subprocess
+import base64
+import json
+
+# 3rd party module
+import requests
+
+MIME_TYPE = 'text/x-commissaire-host'
+handler_version = 2
+
+
+def list_types():
+    return [MIME_TYPE]
+
+
+def run_cmd(cmd, desc, shell=False):
+    try:
+        print('Executing {}'.format(desc))
+        subprocess.check_call(cmd, shell=shell)
+    except FileNotFoundError:
+        print('Missing binary for command {}'.format(cmd))
+        raise
+    except subprocess.CalledProcessError as ex:
+        print('Error trying to {}: {}'.format(desc, str(ex)))
+        raise
+
+
+def handle_part(data, ctype, filename, payload, *args, **kwargs):
+    if ctype == '__begin__':
+        return
+
+    if ctype == '__end__':
+        return
+
+    # Re-raise any exceptions so they get logged, but also print a
+    # useful message before doing so to help ascertain the problem.
+
+    try:
+        config = json.loads(payload)
+        assert type(config) is dict
+    except (AssertionError, ValueError):
+        print('{0}: {1} data must be a JSON object'.format(filename, ctype))
+        return
+
+    if 'endpoint' not in config:
+        print('{0}: Missing required "endpoint" URI'.format(filename))
+        return
+
+    endpoint = config.get('endpoint')
+    username = config.get('username')
+    password = config.get('password')
+    cluster = config.get('cluster')
+    remote_user = config.get('remote_user', 'root')
+    keyfile = config.get('ssh_key_path', '/root/.ssh/id_rsa')
+    authorized_keys = config.get(
+        'authorized_keys_path', '/root/.ssh/authorized_keys')
+
+    # Verify the authorized_keys file exists
+    if not os.path.isfile(authorized_keys):
+        print('Creating authorized_keys {}'.format(authorized_keys))
+        authorized_keys_path, _ = authorized_keys.rsplit('/', 1)
+        os.makedirs(authorized_keys_path)
+        with open(authorized_keys, 'w', ) as _:
+            pass
+        print('Chowning authorized_keys')
+        os.chmod(authorized_keys, 0o600)
+
+    if remote_user != 'root':
+        print('User is {}. Adding...'.format(remote_user))
+        run_cmd(
+            ['/sbin/useradd', remote_user],
+            'add user {}'.format(remote_user))
+        tmp_sudoers = '/tmp/{}'.format(remote_user)
+        run_cmd('/bin/echo "{}    ALL=NOPASSWD: ALL" > {}'.format(
+                remote_user, tmp_sudoers),
+                'create a suoders file for the {}'.format(remote_user),
+                shell=True)
+        run_cmd(
+            ['/bin/cp', tmp_sudoers,
+             '/etc/sudoers.d/{}'.format(remote_user)],
+            'add {} for sudoers'.format(remote_user))
+
+    if not os.path.isfile(keyfile):
+        run_cmd(
+            ['/usr/bin/ssh-keygen', '-q', '-N', '',
+             '-t', 'rsa', '-f', keyfile],
+            'generate key file')
+        home_dir = os.path.expanduser('~' + remote_user)
+        print('home_dir is {}. Calling restorcon'.format(home_dir))
+        run_cmd(
+            ['/sbin/restorecon', '-R', '-v',
+             os.path.sep.join([home_dir, '.ssh'])],
+            'run restorcon on {}'.format(home_dir))
+        run_cmd(
+            ['/bin/chown', '-R', remote_user, home_dir],
+            'chown {} to {}'.format(home_dir, remote_user))
+
+    try:
+        with open(keyfile + '.pub') as inpf:
+            # If creating a new file, set mode to 0600.
+            fd = os.open(authorized_keys,
+                         os.O_WRONLY | os.O_APPEND | os.O_CREAT,
+                         stat.S_IRUSR | stat.S_IWUSR)
+            with os.fdopen(fd, 'a') as outf:
+                outf.writelines(inpf.readlines())
+    except Exception as ex:
+        print('Error writing key to authorized_keys: {}'.format(str(ex)))
+        raise
+
+    body = {
+        'remote_user': remote_user,
+    }
+
+    try:
+        with open(keyfile, 'rb') as f:
+            b64_bytes = base64.b64encode(f.read())
+            body['ssh_priv_key'] = b64_bytes.decode()
+    except Exception as ex:
+        print(str(ex))
+        raise
+
+    if cluster:
+        body['cluster'] = cluster
+
+    uri = '{0}/api/v0/host'.format(endpoint)
+    auth = (username, password) if username and password else None
+
+    # XXX: Older versions of requests.put() had no json= kwarg.
+    headers = {'Content-Type': 'application/json'}
+    resp = requests.put(uri, data=json.dumps(body), auth=auth, headers=headers)
+    print('Commissaire response: {0} {1}'.format(
+        resp.status_code, resp.reason))

--- a/src/commctl/helpers.py
+++ b/src/commctl/helpers.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301  USA
+"""
+Helper commands for use with the CLI but are not specific to the client.
+"""
+
+
+def do_passhash(args):
+    """
+    Uses bcrypt to hash a password.
+
+    :param args: Parsed ArgumentParser args
+    :type args: argparse.Namespace
+    :returns: The hashed password
+    :rtype: str
+    """
+    import bcrypt
+
+    if args.password is not None:
+        pw = args.password
+    elif args.file is not None:
+        pw = args.file.read()
+    else:
+        import getpass
+        pw = getpass.getpass()
+    salt = bcrypt.gensalt(log_rounds=args.rounds)
+    return bcrypt.hashpw(pw, salt)

--- a/src/commctl/helpers.py
+++ b/src/commctl/helpers.py
@@ -104,8 +104,12 @@ def do_user_data(args):
         for msg in sub_messages:
             combined_message.attach(msg)
 
-        # Write out the user-data file
-        with open(args.outfile, 'w') as out:
-            out.write(str(combined_message))
+        # Write out to a file if output is set
+        if args.outfile:
+            # Write out the user-data file
+            with open(args.outfile, 'w') as out:
+                out.write(str(combined_message))
+        else:
+            sys.stdout.write(str(combined_message))
     finally:
         os.unlink(files['x-commissaire-host'])

--- a/src/commctl/helpers.py
+++ b/src/commctl/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016  Red Hat, Inc
+# Copyright (C) 2016-2017  Red Hat, Inc
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Library General Public
@@ -39,3 +39,73 @@ def do_passhash(args):
         pw = getpass.getpass()
     salt = bcrypt.gensalt(log_rounds=args.rounds)
     return bcrypt.hashpw(pw, salt)
+
+
+def do_user_data(args):
+    """
+    Generates a user-data file for cloud-init
+
+    :param args: Parsed ArgumentParser args
+    :type args: argparse.Namespace
+    """
+    import json
+    import os.path
+    import sys
+    import tempfile
+
+    from email.mime.multipart import MIMEMultipart
+    from email.mime.text import MIMEText
+
+    # Holds all thre required files to make our user-data
+    # Keys are the mime-type, values are the paths to the files
+    files = {
+        'cloud-config': os.path.sep.join([
+            os.path.dirname(os.path.realpath(
+                __file__)), 'data', 'cloud-init.txt']),
+        'x-commissaire-host': None,
+        'part-handler': os.path.sep.join([os.path.dirname(
+            os.path.realpath(__file__)), 'data', 'part-handler.py']),
+    }
+
+    if args.cloud_init is not None:
+        files['cloud-config'] = args.cloud_init
+
+    # Create and populate the configuration
+    config_struct = {
+        'endpoint': args.endpoint,
+    }
+    for key in (
+        'username', 'password', 'cluster', 'remote_user',
+            'ssh_key_path', 'authorized_keys_path'):
+        value = getattr(args, key)
+        if value is not None:
+            config_struct[key] = value
+
+    try:
+        # Write the configuration out
+        files['x-commissaire-host'] = tempfile.mktemp()
+        with open(files['x-commissaire-host'], 'w') as f_obj:
+            json.dump(config_struct, f_obj, indent=True)
+
+        sub_messages = []
+        for mtype, fname in files.items():
+            with open(fname, 'r') as f_obj:
+                sub_message = MIMEText(
+                    f_obj.read(),
+                    mtype,
+                    sys.getdefaultencoding())
+                sub_message.add_header(
+                    'Content-Disposition',
+                    'attachment; filename="{}"'.format(
+                        os.path.basename(fname)))
+                sub_messages.append(sub_message)
+        # Pull it all together
+        combined_message = MIMEMultipart()
+        for msg in sub_messages:
+            combined_message.attach(msg)
+
+        # Write out the user-data file
+        with open(args.outfile, 'w') as out:
+            out.write(str(combined_message))
+    finally:
+        os.unlink(files['x-commissaire-host'])

--- a/test/test_client_script.py
+++ b/test/test_client_script.py
@@ -258,6 +258,30 @@ class TestClientScript(TestCase):
             hashed = _out.getvalue().strip()
             self.assertEquals(bcrypt.hashpw('mypass', hashed), hashed)
 
+    def test_client_script_user_data(self):
+        """
+        Verify user-data generates a user-data file.
+        """
+        from email.mime.multipart import MIMEMultipart
+
+        try:
+            output_file = tempfile.mktemp()
+            sys.argv = [
+                '', 'user-data', '-e', 'https://example.com', output_file]
+            client_script.main()
+            with open(output_file, 'r') as f:
+                m = MIMEMultipart(f.read())
+                self.assertTrue(m.is_multipart())
+            filename_count = 0
+            for param in m.get_params():
+                if param[0] == 'filename':
+                    filename_count += 1
+
+            # We should have 3 filenames
+            self.assertEquals(3, filename_count)
+        finally:
+            os.unlink(output_file)
+
 
 class TestMultiServerSession(TestCase):
     """

--- a/test/test_client_script.py
+++ b/test/test_client_script.py
@@ -267,7 +267,8 @@ class TestClientScript(TestCase):
         try:
             output_file = tempfile.mktemp()
             sys.argv = [
-                '', 'user-data', '-e', 'https://example.com', output_file]
+                '', 'user-data',
+                '-e', 'https://example.com', '-o', output_file]
             client_script.main()
             with open(output_file, 'r') as f:
                 m = MIMEMultipart(f.read())


### PR DESCRIPTION
- Rearanges the helper commands in ``commctl``
- Adds ``user-data`` to replace much of [these](http://commissaire.readthedocs.io/en/latest/cloud_init.html) manual steps
- Adds in data files to generate the user-data output

A follow on for ``commissaire`` to update docs will be done once this merges.

## Example
```
$ commctl user-data --password -u my_commissaire_user \
   -e http://api.example.com \
   output.userdata
Password:
```

Reference: https://github.com/projectatomic/commissaire/issues/128

/cc @tbielawa