### PR TITLE
cli: Add host join/unjoin commands.

### DIFF
--- a/src/commctl/cli.py
+++ b/src/commctl/cli.py
@@ -386,6 +386,18 @@ class Client(object):
             result.append(self._delete(path))
         return result
 
+    def host_join(self, address, cluster_name, **kwargs):
+        """
+        Attempts to join a host to a cluster.
+
+        :param address: The IP address of the host
+        :type address: str
+        :param cluster_name: The name of the cluster
+        :type cluster_name: str
+        """
+        path = '/api/v0/cluster/{0}/hosts/{1}'.format(cluster_name, address)
+        return self._put(path)
+
     def host_status(self, address, **kwargs):
         """
         Attempts to get the status of a host.
@@ -397,6 +409,18 @@ class Client(object):
         """
         path = '/api/v0/host/{0}/status'.format(address)
         return self._get(path)
+
+    def host_unjoin(self, address, cluster_name, **kwargs):
+        """
+        Attempts to unjoin a host from a cluster.
+
+        :param address: The IP address of the host
+        :type address: str
+        :param cluster_name: The name of the cluster
+        :type cluster_name: str
+        """
+        path = '/api/v0/cluster/{0}/hosts/{1}'.format(cluster_name, address)
+        return self._delete(path)
 
     def cluster_deploy_status(self, name, **kwargs):
         """
@@ -962,6 +986,16 @@ def add_host_commands(argument_parser):
         'address', type=host_address,
         help='Host name or IP address')
 
+    # Sub-command: host join
+    verb_parser = subject_subparser.add_parser('join')
+    verb_parser.required = True
+    verb_parser.add_argument(
+        'address', type=host_address,
+        help='Host name or IP address')
+    verb_parser.add_argument(
+        'cluster_name',
+        help='Name of the cluster to join with')
+
     # Sub-command: host list
     verb_parser = subject_subparser.add_parser('list')
     verb_parser.add_argument(
@@ -977,13 +1011,22 @@ def add_host_commands(argument_parser):
 
     # Sub-command: host ssh
     verb_parser = subject_subparser.add_parser('ssh')
-
     verb_parser.required = True
     verb_parser.add_argument(
         'hostname', help='Host to connect to. EX: 10.1.1.1')
     verb_parser.add_argument(
         'extra_args', nargs=argparse.REMAINDER,
         help='Any other arguments to pass to ssh')
+
+    # Sub-command: host unjoin
+    verb_parser = subject_subparser.add_parser('unjoin')
+    verb_parser.required = True
+    verb_parser.add_argument(
+        'address', type=host_address,
+        help='Host name or IP address')
+    verb_parser.add_argument(
+        'cluster_name',
+        help='Name of the cluster to unjoin from')
 
 
 def add_network_commands(argument_parser):

--- a/test/test_client_script.py
+++ b/test/test_client_script.py
@@ -127,7 +127,8 @@ class TestClientScript(TestCase):
                     ['container_manager', 'create'],
                     ['container_manager', 'create', '-o', '"{}"'],
                     ['container_manager', 'create'],
-                    ['host', 'create', '-c', 'honeynut', '1.2.3.4']):
+                    ['host', 'create', '-c', 'honeynut', '1.2.3.4'],
+                    ['host', 'join', '1.2.3.4']):
                 mock_return = requests.Response()
                 mock_return._content = '{}'
                 mock_return.status_code = 201
@@ -157,6 +158,7 @@ class TestClientScript(TestCase):
                     ['container_manager', 'delete', 'test', 'test2'],
                     ['host', 'delete', 'localhost'],
                     ['host', 'delete', '10.0.0.1', '10.0.0.2', '10.0.0.3'],
+                    ['host', 'unjoin', '1.2.3.4', 'honeynut'],
                     ['network', 'delete', 'test'],
                     ['network', 'delete', 'test', 'test2', 'test3']):
                 mock_return = requests.Response()
@@ -167,7 +169,10 @@ class TestClientScript(TestCase):
                 sys.argv[1:] = cmd
                 print(sys.argv)
                 client_script.main()
-                num_things = len(cmd) - 2
+                if cmd[1] == 'unjoin':
+                    num_things = 1
+                else:
+                    num_things = len(cmd) - 2
                 self.assertEquals(num_things, _delete.call_count)
                 _delete.reset_mock()
 


### PR DESCRIPTION
Simple way to add or remove individual cluster members.
```
   commctl host join ADDRESS CLUSTERNAME

   commctl host unjoin ADDRESS CLUSTERNAME
```
Wanted this for some notification testing.