### PR TITLE
Make "container_manager create" easier to use

### DIFF
--- a/src/commctl/cli.py
+++ b/src/commctl/cli.py
@@ -320,7 +320,7 @@ class Client(object):
         path = '/api/v0/containermanager/{0}'.format(name)
         print(path)
         data = {
-            'type': 'openshift',  # TODO: Update when more types are added
+            'type': kwargs['type'],
             'options': kwargs.get('options', {}),
         }
 
@@ -915,10 +915,9 @@ def add_container_manager_commands(argument_parser):
     # Sub-command: container_manager create
     verb_parser = subject_subparser.add_parser('create')
     verb_parser.required = True
-    # XXX: Update when more choices are added.
-    # verb_parser.add_argument(
-    #     '-t', '--type', help='Type of the container manager',
-    #     choices=('openshift', ), default='openshift')
+    verb_parser.add_argument(
+        '-t', '--type', default='openshift',
+        help='Type of the container manager (default: openshift)')
     verb_parser.add_argument(
         '-o', '--options', help='Options for the container manager',
         default={})

--- a/test/test_client_script.py
+++ b/test/test_client_script.py
@@ -125,7 +125,7 @@ class TestClientScript(TestCase):
                     ['cluster', 'restart', 'start'],
                     ['cluster', 'upgrade', 'start'],
                     ['container_manager', 'create'],
-                    ['container_manager', 'create', '-o', '"{}"'],
+                    ['container_manager', 'create', '-o', '{}'],
                     ['container_manager', 'create'],
                     ['host', 'create', '-c', 'honeynut', '1.2.3.4'],
                     ['host', 'join', '1.2.3.4']):


### PR DESCRIPTION
I reinstated the `--type` option so I could play with the `'trivial'` type of container managers.

Also, the `--options` usage blurb gives no indication of what input it expects, so I tried to correct for this.  `--options` can now be specified multiple times and is cumulative.